### PR TITLE
hackish support for reading laz files 

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -9,24 +9,34 @@ import copy
 
 
 class FakeMmap(object):
-    def __init__(self,data,pos=0):
-        self.view=memoryview(data)
-        self.pos=pos
-        #numpy needs this, unfortunaltely
-        self.__buffer__=buffer(data) 
-    def __getitem__(self,i):
+    '''
+    An object imitating a memory mapped file,
+    constructed from 'buffer like' data.
+    '''
+    def __init__(self, data, pos=0):
+        self.view = memoryview(data)
+        self.pos = pos
+        # numpy needs this, unfortunately
+        self.__buffer__ = buffer(data)
+    
+    def __getitem__(self, i):
         return self.view[i]
+    
     def close(self):
-        self.view=None
+        self.view = None
+    
     def flush(self):
         pass
-    def seek(self,bytes,pos):
-        if pos>0:
-            self.pos+=bytes
+    
+    def seek(self, nbytes, pos):
+        if pos > 0:
+            self.pos += nbytes
         else:
-            self.pos=bytes
-    def read(self,bytes):
-        return self.view[self.pos:self.pos+bytes]
+            self.pos = nbytes
+            
+    def read(self, nbytes):
+        return self.view[self.pos:self.pos+nbytes]
+        
     def tell(self):
         return self.pos
   
@@ -221,7 +231,7 @@ class FileManager():
 
         if self.point_format.compressed:
             self.compressed = True
-            print("Warning: Compressed data was detected and will not be read.")
+            print("Warning: Compressed data was detected.")
         else:
             self.compressed = False        
             self.data_provider.point_map()

--- a/laspy/file.py
+++ b/laspy/file.py
@@ -731,12 +731,14 @@ class File(object):
 
 def read_compressed(filename):
     import subprocess
-    prc=subprocess.Popen(["laszip", "-olas", "-stdout", "-i",filename],stdout=subprocess.PIPE,bufsize=-1)
+    prc=subprocess.Popen(["laszip", "-olas", "-stdout", "-i", filename],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=-1)
     data, stderr=prc.communicate()
     if prc.returncode != 0:
-        sys.stderr.write("Unusual return code from laszip: %d, is laszip installed?\n" %prc.returncode)
-        if stderr and len(stderr)<512:
-            sys.stderr.write(stderr+"\n")
+        # What about using the logging module instead of prints?
+        print("Unusual return code from laszip: %d" %prc.returncode)
+        if stderr and len(stderr)<2048:
+            print(stderr)
         raise ValueError("Unable to read compressed file!")
     return data
     


### PR DESCRIPTION
Inspired by slash by Thomas Knudsen, http://bitbucket.org/busstop/helios . We currently use that for reading laz-files in our LIDAR QC-code: http://bitbucket.org/GSTudvikler/gstdhmqc

Implements basic support for reading laz-files via a call to laszip and a buffer object. Currently numpy does not seem to be able to create arrays from memoryviews, so both buffer and memoryview used in FakeMmap. Had to disable populate_evlrs for this hack, due to a KeyError in the header_format.lookup -mapping. Tested to work on win7 from Osgeo4W64. Only read-mode implemented...