### PR TITLE
Fixed bug opening files without write permission

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -28,6 +28,7 @@ class DataProvider():
             self.fileref = open(self.filename, mode)
         except(Exception):
             raise laspy.util.LaspyException("Error opening file")
+
     def get_point_map(self, informat):
         '''Get point map is used to build and return a numpy frombuffer view of the mmapped data, 
         using a valid laspy.util.Format instance for the desired point format. This method is used 
@@ -163,19 +164,26 @@ class FileManager():
         self._current = 0 
         
         self.padded = False
-        if self.mode in ("r", "rw"):
-            self.setup_read_write(vlrs, evlrs)
+        if self.mode == "r":
+            self.setup_read_write(vlrs,evlrs, read_only=True)
             return
-
+        elif self.mode == "rw":
+            self.setup_read_write(vlrs, evlrs, read_only=False)
+            return
         elif self.mode == "w":
             self.setup_write(header, vlrs, evlrs)
             return
         else:
             raise laspy.util.LaspyException("Append Mode Not Supported")
         
-    def setup_read_write(self, vlrs, evlrs):
+    def setup_read_write(self, vlrs, evlrs, read_only=True):
+        # Check if read only mode, if not open for updating.
+        if read_only:
+            open_mode = "rb"
+        else:
+            open_mode = "r+b"
         self._header_current = True
-        self.data_provider.open("r+b")
+        self.data_provider.open(open_mode)
         self.data_provider.map() 
         self.header_format = laspy.util.Format("h" + self.grab_file_version())
         self.get_header(self.grab_file_version())


### PR DESCRIPTION
By default if 'r' or 'rw' mode was requested files were being opened in append mode. This caused problems for files without write access in 'r' mode. 

Have updated so if 'r' mode is requested will only open file in read mode by modifying 'setup_read_write' to add a read_only flag.