### PR TITLE
doc fix: point format 0-5 classification is 5 bits

### DIFF
--- a/doc/source/tut_background.rst
+++ b/doc/source/tut_background.rst
@@ -141,7 +141,7 @@ in the same way as full size dimensions:
 ======================  ====================  ==============================
  Field Name              Laspy Abbreviation    Length(in bits)
 ======================  ====================  ==============================
- Classification          classification        4
+ Classification          classification        5
  Synthetic               synthetic             1
  Key Point               key_point             1
  Withheld                withheld              1


### PR DESCRIPTION
Now the classification byte adds up to 8 bits :)
The code is correct.