### PR TITLE
Speed up writing

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -1029,8 +1029,9 @@ class HeaderManager(object):
 
     def update_histogram(self):
         '''Update the histogram of returns by number'''
-        rawdata = map(lambda x: (x==0)*1 + (x!=0)*x, 
-                     self.writer.get_return_num())
+        rawdata = self.writer.get_return_num()
+        rawdata[rawdata == 0] = 1#
+
         #if self.version == "1.3":
         #    histDict = {1:0, 2:0, 3:0, 4:0, 5:0, 6:0, 7:0}
         #elif self.version in ["1.0", "1.1", "1.2"]:


### PR DESCRIPTION
When writing files with `laspy` a significant amount of time is spent on updating histograms. Most of this time can be contributed to a slow python map and lambda function combination in `header.update_histograms`. With this PR I have replaced the slow map with an equivalent numpy logical expression. Below a quick test of write speed before and after can be seen.

The test script:
```python
'''
copy_las.py
'''

import laspy

input = '/Users/kevers/data/biglas.las' # 612 MB las-file
output = 'out.las'

las_in = laspy.file.File(input, mode='r')
las_out = laspy.file.File(output, header=las_in.header, mode='w')

las_out.points = las_in.points
las_out.z += 2.3 # just a random operation to ensure in and out files are different

las_in.close()
las_out.close()
```

Time the script for the old code:
```
$ time python copy_test.py 

real	8m24.694s
user	6m39.584s
sys	0m18.958s
```

Timing for the new code:
```
$ time python copy_test.py 

real	1m57.515s
user	0m30.404s
sys	0m16.085s
```

As seen by the time outputs there's a speed up of more than a factor 4. It might be different for smaller or larger files - I haven't investigated how the speed up scales with larger file sizes. 