### PR TITLE
Removed unnecessary ndarray to list conversion. Speeds up writing significantly.

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -1065,9 +1065,9 @@ class HeaderManager(object):
             scale=True
         elif minmax_mode != "scaled":
             scale=False
-        x = list(self.writer.get_x(scale))
-        y = list(self.writer.get_y(scale))
-        z = list(self.writer.get_z(scale)) 
+        x = self.writer.get_x(scale)
+        y = self.writer.get_y(scale)
+        z = self.writer.get_z(scale)
         self.writer.set_header_property("x_max", np.max(x))
         self.writer.set_header_property("x_min", np.min(x))
         self.writer.set_header_property("y_max", np.max(y))


### PR DESCRIPTION
In line with PR #49 I have changed a few lines to use numpy more directly and save time by not using pythons slow functions. In this particular case a numpy ndarray was unnecessarily converted to a python list.

A simple test script to show the improvements:
```python
'''
copy_las.py
'''

import laspy
import time

input = 'C:/data/1km_6147_892.las'
output = 'out.las'

t1 = time.time()

las_in = laspy.file.File(input, mode='r')
las_out = laspy.file.File(output, header=las_in.header, mode='w')

las_out.points = las_in.points
las_out.z += 2.3 # just a random operation to ensure in and out files are different

las_in.close()
las_out.close()

print(time.time()-t1
```

And the results
```
# run test script with new and improved code
C:\dev\laspy>python copy_las.py
1.07800006866

# stash uncommitted changes and revert header.py to most recent version from master
C:\dev\laspy>git stash
Saved working directory and index state WIP on write-faster: c4adbd7 Create .travis.yml
HEAD is now at c4adbd7 Create .travis.yml

# same test script with the old code
C:\dev\laspy>python copy_las.py
3.82899999619
```

That is roughly a speed up of a factor 3.5. All in all with this PR and #49 my production code that copies and applies a geoid offset to a las-file, has gone from executing in ~29 seconds to less than 2 seconds.
